### PR TITLE
Update TextReplace

### DIFF
--- a/TextReplace/build.gradle.kts
+++ b/TextReplace/build.gradle.kts
@@ -1,2 +1,2 @@
-version = "1.0.3"
+version = "1.0.4"
 description = "Customizable text replacer."

--- a/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/TextReplace.kt
+++ b/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/TextReplace.kt
@@ -33,7 +33,7 @@ class TextReplace : Plugin() {
     }
 
     override fun load(context: Context) {
-        pluginIcon = ContextCompat.getDrawable(context, Utils.getResId("drawable_icon_sync_integration", "drawable"))
+        pluginIcon = ContextCompat.getDrawable(context, Utils.getResId("drawable_icon_sync_integration", "drawable"))!!
     }
 
     override fun start(context: Context) {

--- a/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/TextReplace.kt
+++ b/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/TextReplace.kt
@@ -1,5 +1,7 @@
 package cloudburst.plugins.textreplace
 
+import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
 import com.aliucord.annotations.AliucordPlugin
 import com.aliucord.entities.Plugin
 import com.aliucord.patcher.Hook
@@ -20,6 +22,7 @@ import cloudburst.plugins.textreplace.ui.ReplacerSettings
 
 @AliucordPlugin
 class TextReplace : Plugin() {
+    lateinit var pluginIcon: Drawable
     private val textContentField =
     MessageContent::class.java.getDeclaredField("textContent").apply {
         isAccessible = true
@@ -27,6 +30,10 @@ class TextReplace : Plugin() {
 
     init {
         settingsTab = SettingsTab(ReplacerSettings::class.java)
+    }
+
+    override fun load(context: Context) {
+        pluginIcon = ContextCompat.getDrawable(context, Utils.getResId("drawable_icon_sync_integration", "drawable"))
     }
 
     override fun start(context: Context) {

--- a/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/ui/ReplacementCard.kt
+++ b/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/ui/ReplacementCard.kt
@@ -1,9 +1,13 @@
 package cloudburst.plugins.textreplace.ui
 
 import android.content.Context
+import android.view.View
+import androidx.cardview.widget.CardView
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.textfield.TextInputLayout
 import com.aliucord.views.TextInput
 import com.aliucord.utils.DimenUtils
+import com.aliucord.utils.ReflectUtils
 import com.discord.utilities.color.ColorCompat
 import com.lytefast.flexinput.R
 import cloudburst.plugins.textreplace.utils.TextReplacement
@@ -28,10 +32,12 @@ class ReplacerCard(ctx: Context) : MaterialCardView(ctx) {
             setPadding(p, p, p, p)
         }
 
-        fromInput = TextInput(ctx, "From")
+        fromInput = TextInput(ctx)
+        fromInput.setInputHint("From")
         linearLayout.addView(fromInput)
 
-        replacementInput = TextInput(ctx, "To")
+        replacementInput = TextInput(ctx)
+        replacementInput.setInputHint("To")
         linearLayout.addView(replacementInput)
 
         isRegex = Utils.createCheckedSetting(
@@ -75,6 +81,16 @@ class ReplacerCard(ctx: Context) : MaterialCardView(ctx) {
         linearLayout.addView(matchEmbeds)
 
         addView(linearLayout)
+    }
+
+
+    fun TextInput.setInputHint(hint: CharSequence) {
+        if (this is CardView) {
+            val root = ReflectUtils.invokeMethod(this, "getRoot") as TextInputLayout
+            root.hint = hint
+        } else {
+            (this as TextInputLayout).hint = hint
+        }
     }
 
     public fun apply(replacement: TextReplacement) {

--- a/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/ui/ReplacerSettings.kt
+++ b/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/ui/ReplacerSettings.kt
@@ -19,7 +19,6 @@ import com.aliucord.views.Button
 import com.aliucord.views.ToolbarButton
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import com.lytefast.flexinput.R
 import com.aliucord.fragments.InputDialog
 
 class ReplacerSettings : SettingsPage() {
@@ -119,8 +118,8 @@ class ReplacerSettings : SettingsPage() {
             exportBtn.setPadding(p, p, p, p)
             importBtn.setPadding(p, p, p, p)
 
-            exportBtn.setImageDrawable(ContextCompat.getDrawable(ctx, R.e.ic_file_download_white_24dp))
-            importBtn.setImageDrawable(ContextCompat.getDrawable(ctx, R.e.ic_file_upload_24dp))
+            exportBtn.setImageDrawable(ContextCompat.getDrawable(ctx, Utils.getResId("ic_file_download_white_24dp", "drawable")))
+            importBtn.setImageDrawable(ContextCompat.getDrawable(ctx, Utils.getResId("ic_file_upload_24dp", "drawable")))
 
             addHeaderButton(exportBtn)
             addHeaderButton(importBtn)


### PR DESCRIPTION
• Add pluginIcon for those using the dedicated plugin settings plugin
• Set TextInput's hint a in a backwards compatible way (NEEDS TESTING on the newer Aliucord versions where TextInput inherits CardView though, haven't tested it myself)
• Use Utils to get resource IDs instead of lytefast as it is more reliable (causes crash on my version, seemingly because lytefast doesn't have the necessary IDs) 